### PR TITLE
Changed from JDK 23 to 21 to work with GCP

### DIFF
--- a/chapter_chai/backend/pom.xml
+++ b/chapter_chai/backend/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>23</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Java 21 is the latest version that is supported by Google Cloud Platform, so this is a simple 1-line diff to adjust the pom.xml file to transition from JDK 23 to 21. Below is a screenshot confirming that the maven build (generated by `mvn package`) is successful locally. 

<img width="942" alt="image" src="https://github.com/user-attachments/assets/9577c35b-27a9-4d1d-a5e3-3f4b2d7557b0">
